### PR TITLE
Add size assert, refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ In this module we build a small `Tensor` in C, along the lines of `torch.Tensor`
 The source code of the 1D Tensor is in [tensor1d.h](tensor1d.h) and [tensor1d.c](tensor1d.c). You can compile and run this simply as:
 
 ```bash
-gcc -Wall -O3 tensor1d.c -o tensor1d
+gcc -Wall -O3 tensor1d.c -o tensor1d -lm
 ./tensor1d
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ In this module we build a small `Tensor` in C, along the lines of `torch.Tensor`
 The source code of the 1D Tensor is in [tensor1d.h](tensor1d.h) and [tensor1d.c](tensor1d.c). You can compile and run this simply as:
 
 ```bash
-gcc -Wall -O3 tensor1d.c -o tensor1d -lm
+gcc -Wall -O3 tensor1d.c -o tensor1d
 ./tensor1d
 ```
 

--- a/tensor1d.c
+++ b/tensor1d.c
@@ -30,7 +30,7 @@ void *malloc_check(size_t size, const char *file, int line) {
 // ----------------------------------------------------------------------------
 // utils
 
-inline int ceil_div(int a, int b) {
+int ceil_div(int a, int b) {
     // integer division that rounds up, i.e. ceil(a / b)
     return (a + b - 1) / b;
 }
@@ -41,6 +41,7 @@ inline int ceil_div(int a, int b) {
 // similar to torch.Storage
 
 Storage* storage_new(int size) {
+    assert(size > 0);
     Storage* storage = mallocCheck(sizeof(Storage));
     storage->data = mallocCheck(size * sizeof(float));
     storage->data_size = size;
@@ -157,11 +158,9 @@ Tensor* tensor_slice(Tensor* t, int start, int end, int step) {
     // 1) handle negative indices by wrapping around
     if (start < 0) { start = t->size + start; }
     if (end < 0) { end = t->size + end; }
-    // 2) handle out-of-bounds indices: clip to 0 and t->size
-    if (start < 0) { start = 0; }
-    if (end < 0) { end = 0; }
-    if (start > t->size) { start = t->size; }
-    if (end > t->size) { end = t->size; }
+    // 2) handle out-of-bounds indices: clip to [0, t->size] range
+    start = fmin(fmax(start, 0), t->size);
+    end = fmin(fmax(end, 0), t->size);
     // 3) handle step
     if (step == 0) {
         fprintf(stderr, "ValueError: slice step cannot be zero\n");

--- a/tensor1d.c
+++ b/tensor1d.c
@@ -35,13 +35,21 @@ int ceil_div(int a, int b) {
     return (a + b - 1) / b;
 }
 
+int min(int a, int b) {
+    return (a < b) ? a : b;
+}
+
+int max(int a, int b) {
+    return (a > b) ? a : b;
+}
+
 // ----------------------------------------------------------------------------
 // Storage: simple array of floats, defensive on index access, reference-counted
 // The reference counting allows multiple Tensors sharing the same Storage.
 // similar to torch.Storage
 
 Storage* storage_new(int size) {
-    assert(size > 0);
+    assert(size >= 0);
     Storage* storage = mallocCheck(sizeof(Storage));
     storage->data = mallocCheck(size * sizeof(float));
     storage->data_size = size;
@@ -159,8 +167,8 @@ Tensor* tensor_slice(Tensor* t, int start, int end, int step) {
     if (start < 0) { start = t->size + start; }
     if (end < 0) { end = t->size + end; }
     // 2) handle out-of-bounds indices: clip to [0, t->size] range
-    start = fmin(fmax(start, 0), t->size);
-    end = fmin(fmax(end, 0), t->size);
+    start = min(max(start, 0), t->size);
+    end = min(max(end, 0), t->size);
     // 3) handle step
     if (step == 0) {
         fprintf(stderr, "ValueError: slice step cannot be zero\n");


### PR DESCRIPTION
Minor refactor + added size assert.

`inline` was causing compile failures on my Linux machine, i think if we want to make it inline we'd have to move it to the header file (but then again see my next comment on simplicity vs robustness tradeoff so if we err on the simplicity side i say let's just omit this minor optimization (?)).