### PR TITLE
fix memory leak

### DIFF
--- a/tensor1d.c
+++ b/tensor1d.c
@@ -208,7 +208,6 @@ char* tensor_to_string(Tensor* t) {
 void tensor_print(Tensor* t) {
     char* str = tensor_to_string(t);
     printf("%s\n", str);
-    free(str);
 }
 
 void tensor_free(Tensor* t) {
@@ -232,5 +231,10 @@ int main(int argc, char *argv[]) {
     // print element -1
     float val = tensor_getitem(ss, -1);
     printf("ss[-1] = %.1f\n", val);
+
+    tensor_free(ss);
+    tensor_free(s);
+    tensor_free(t);
+    
     return 0;
 }


### PR DESCRIPTION
**compile the original code with asan**
```
===================================================================
24057==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 2 object(s) allocated from:
    #0 0x7fae367f5808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x55c2b4f0781d in tensor_slice (/home/jake/eureka/tensor/tensor1d+0x381d)

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7fae367f5808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x55c2b4f06be3 in tensor_empty (/home/jake/eureka/tensor/tensor1d+0x2be3)

Indirect leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7fae367f5808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x55c2b4f06c11 in tensor_empty (/home/jake/eureka/tensor/tensor1d+0x2c11)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7fae367f5808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x55c2b4f06bf9 in tensor_empty (/home/jake/eureka/tensor/tensor1d+0x2bf9)

SUMMARY: AddressSanitizer: 192 byte(s) leaked in 5 allocation(s).
```

**add tensor_free() and compile with asan**
```
===================================================================
25275==ERROR: AddressSanitizer: attempting double-free on 0x606000000020 in thread T0:
    #0 0x7f9cba68540f in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:122
    #1 0x55c9be965bcd in tensor_free (/home/jake/eureka/tensor/tensor1d+0x3bcd)
    #2 0x55c9be964350 in main (/home/jake/eureka/tensor/tensor1d+0x2350)
    #3 0x7f9cba3aa082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
    #4 0x55c9be9643cd in _start (/home/jake/eureka/tensor/tensor1d+0x23cd)

0x606000000020 is located 0 bytes inside of 63-byte region [0x606000000020,0x60600000005f)
freed by thread T0 here:
    #0 0x7f9cba68540f in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:122
    #1 0x55c9be964321 in main (/home/jake/eureka/tensor/tensor1d+0x2321)

previously allocated by thread T0 here:
    #0 0x7f9cba685808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x55c9be96454b in tensor_to_string.part.0 (/home/jake/eureka/tensor/tensor1d+0x254b)

SUMMARY: AddressSanitizer: double-free ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:122 in __interceptor_free
==25275==ABORTING
```

I think free(str) in tensor_print(Tensor* t) function already freed t->repr when calling tensor_free().
so I simply removed this line. and add tensor_free() 

 