### PR TITLE
Feature tensor zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ t3 = t + t2
 
 # add two tensors together with broadcasting
 t4 = t + tensor1d.tensor([10.0])
+
+# initialize tensors with zeros
+t5 = tensor1d.zeros(20)
 ```
 
 Finally the tests use [pytest](https://docs.pytest.org/en/stable/) and can be found in [test_tensor1d.py](test_tensor1d.py). You can run this as `pytest test_tensor1d.py`.

--- a/tensor1d.c
+++ b/tensor1d.c
@@ -296,7 +296,7 @@ void tensor_free(Tensor* t) {
 // ----------------------------------------------------------------------------
 
 int main(int argc, char *argv[]) {
-    // tensor empty?
+    // tensor empty
     Tensor* te = tensor_empty(20);
     tensor_print(te);
     // tensor zeros

--- a/tensor1d.c
+++ b/tensor1d.c
@@ -28,6 +28,16 @@ void *malloc_check(size_t size, const char *file, int line) {
 }
 #define mallocCheck(size) malloc_check(size, __FILE__, __LINE__)
 
+void *calloc_check(size_t size, size_t elem_size, const char *file, int line) {
+    void *ptr = calloc(size, elem_size);
+    if (ptr == NULL) {
+        fprintf(stderr, "Error: Memory allocation failed at %s:%d\n", file, line);
+        exit(EXIT_FAILURE);
+    }
+    return ptr;
+}
+#define callocCheck(size, elem_size) calloc_check(size, elem_size, __FILE__, __LINE__)
+
 // ----------------------------------------------------------------------------
 // utils
 
@@ -53,6 +63,15 @@ Storage* storage_new(int size) {
     assert(size >= 0);
     Storage* storage = mallocCheck(sizeof(Storage));
     storage->data = mallocCheck(size * sizeof(float));
+    storage->data_size = size;
+    storage->ref_count = 1;
+    return storage;
+}
+
+Storage* storage_zeros(int size) {
+    assert(size >= 0);
+    Storage* storage = mallocCheck(sizeof(Storage));
+    storage->data = callocCheck(size, sizeof(float));
     storage->data_size = size;
     storage->ref_count = 1;
     return storage;
@@ -87,6 +106,19 @@ void storage_decref(Storage* s) {
 Tensor* tensor_empty(int size) {
     Tensor* t = mallocCheck(sizeof(Tensor));
     t->storage = storage_new(size);
+    // at init we cover the whole storage, i.e. range(start=0, stop=size, step=1)
+    t->offset = 0;
+    t->size = size;
+    t->stride = 1;
+    // holds the text representation of the tensor
+    t->repr = NULL;
+    return t;
+}
+
+// torch.zeros(size)
+Tensor* tensor_zeros(int size){
+    Tensor* t = mallocCheck(sizeof(Tensor));
+    t->storage = storage_zeros(size);
     // at init we cover the whole storage, i.e. range(start=0, stop=size, step=1)
     t->offset = 0;
     t->size = size;
@@ -264,6 +296,12 @@ void tensor_free(Tensor* t) {
 // ----------------------------------------------------------------------------
 
 int main(int argc, char *argv[]) {
+    // tensor empty?
+    Tensor* te = tensor_empty(20);
+    tensor_print(te);
+    // tensor zeros
+    Tensor* tz = tensor_zeros(20);
+    tensor_print(tz);
     // create a tensor with 20 elements
     Tensor* t = tensor_arange(20);
     tensor_print(t);
@@ -280,6 +318,8 @@ int main(int argc, char *argv[]) {
     tensor_free(ss);
     tensor_free(s);
     tensor_free(t);
+    tensor_free(te);
+    tensor_free(tz);
 
     return 0;
 }

--- a/tensor1d.h
+++ b/tensor1d.h
@@ -24,6 +24,7 @@ typedef struct {
 } Tensor;
 
 Tensor* tensor_empty(int size);
+Tensor* tensor_zeros(int size);
 int logical_to_physical(Tensor *t, int ix);
 float tensor_getitem(Tensor* t, int ix);
 Tensor* tensor_getitem_astensor(Tensor* t, int ix);

--- a/tensor1d.py
+++ b/tensor1d.py
@@ -19,6 +19,7 @@ typedef struct {
 } Tensor;
 
 Tensor* tensor_empty(int size);
+Tensor* tensor_zeros(int size);
 int logical_to_physical(Tensor *t, int ix);
 float tensor_getitem(Tensor* t, int ix);
 Tensor* tensor_getitem_astensor(Tensor* t, int ix);
@@ -114,6 +115,10 @@ def empty(size):
 
 def arange(size):
     c_tensor = lib.tensor_arange(size)
+    return Tensor(c_tensor=c_tensor)
+
+def zeros(size):
+    c_tensor = lib.tensor_zeros(size)
     return Tensor(c_tensor=c_tensor)
 
 def tensor(data):

--- a/test_tensor1d.py
+++ b/test_tensor1d.py
@@ -23,6 +23,12 @@ def test_empty(size):
     tensor1d_tensor = tensor1d.empty(size)
     assert len(torch_tensor) == len(tensor1d_tensor)
 
+@pytest.mark.parametrize("size", [0, 1, 10, 100])
+def test_zeros(size):
+    torch_tensor = torch.zeros(size)
+    tensor1d_tensor = tensor1d.zeros(size)
+    assert len(torch_tensor) == len(tensor1d_tensor)
+
 @pytest.mark.parametrize("index", range(1, 10))
 def test_indexing(index):
     torch_tensor = torch.arange(10, dtype=torch.float32)


### PR DESCRIPTION
After an interesting deep dive into how torch initializes tensors with zeros(1), and several detours on how calloc and malloc actually behave (2) + why it is better to use calloc than malloc+memset (3), decided to use calloc for initializing tensor with 0s.

Also learned that **Memory coming from the OS will be zeroed for security reasons.*** ! (4)


----
(1) - Uses memset (https://github.com/pytorch/pytorch/blob/50595ecef4a4f9882a02539019b11a5e50295244/aten/src/ATen/native/Fill.cpp#L150)
(2) - https://stackoverflow.com/questions/1538420/difference-between-malloc-and-calloc
(3) - https://stackoverflow.com/questions/2688466/why-mallocmemset-is-slower-than-calloc?lq=1
(4) - https://stackoverflow.com/a/8029624/2697940
