### PR TITLE
Fix for negative index

### DIFF
--- a/tensor1d.c
+++ b/tensor1d.c
@@ -119,7 +119,7 @@ float tensor_getitem(Tensor* t, int ix) {
     // handle negative indices by wrapping around
     if (ix < 0) { ix = t->size + ix; }
     // oob indices raise IndexError (and we return NaN)
-    if (ix >= t->size) {
+    if (ix < 0 || ix >= t->size) {
         fprintf(stderr, "IndexError: index %d is out of bounds of %d\n", ix, t->size);
         return NAN;
     }


### PR DESCRIPTION
On line 122 we still need to check `ix < 0` and generate IndexError if so - just like we do for `ix >= t->size`.